### PR TITLE
Hippo publishing

### DIFF
--- a/templates/assembly-script/.github/workflows/release.hippo.yml
+++ b/templates/assembly-script/.github/workflows/release.hippo.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install hippofactory
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.2.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
+        wget https://github.com/deislabs/hippofactory/releases/download/v0.3.0/hippofactory-v0.3.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
         tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
 
     - name: Publish bindle (tagged)

--- a/templates/assembly-script/.github/workflows/release.hippo.yml
+++ b/templates/assembly-script/.github/workflows/release.hippo.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install hippofactory
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.1.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
+        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.2.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
         tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
 
     - name: Publish bindle

--- a/templates/assembly-script/.github/workflows/release.hippo.yml
+++ b/templates/assembly-script/.github/workflows/release.hippo.yml
@@ -1,0 +1,47 @@
+name: release
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+env:
+  ACR_NAME: <%= registryName %>
+
+jobs:
+  publish:
+    name: Build release assets
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+
+    - name: Set the release version (tag)
+      if: startsWith(github.ref, 'refs/tags/v')
+      shell: bash
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    - name: Set the release version (main)
+      if: github.ref == 'refs/heads/main'
+      shell: bash
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
+
+    - name: Build release
+      run: |
+        npm install
+        npm run build
+
+    - name: Install hippofactory
+      run: |
+        mkdir -p tools/tmp
+        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.1.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
+        tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
+
+    - name: Publish bindle
+      run: ./tools/hippofactory . -v production -o message

--- a/templates/assembly-script/.github/workflows/release.hippo.yml
+++ b/templates/assembly-script/.github/workflows/release.hippo.yml
@@ -43,5 +43,10 @@ jobs:
         wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.2.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
         tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
 
-    - name: Publish bindle
+    - name: Publish bindle (tagged)
+      if: startsWith(github.ref, 'refs/tags/v')
       run: ./tools/hippofactory . -v production -o message
+
+    - name: Publish bindle (main)
+      if: github.ref == 'refs/heads/main'
+      run: USER=canary ./tools/hippofactory . -o message

--- a/templates/assembly-script/.github/workflows/release.hippo.yml
+++ b/templates/assembly-script/.github/workflows/release.hippo.yml
@@ -7,7 +7,7 @@ on:
       - "v*"
 
 env:
-  ACR_NAME: <%= registryName %>
+  BINDLE_SERVER_URL: <%= serverUrl %>
 
 jobs:
   publish:

--- a/templates/assembly-script/HIPPOFACTS
+++ b/templates/assembly-script/HIPPOFACTS
@@ -3,5 +3,6 @@ name = "<%= moduleName %>"
 version = "0.1.0"
 authors = ["<%= authorName %>"]
 
-[files]
-wasm = ["build/optimized.wasm"]
+[[handler]]
+route = "/"
+name = "build/optimized.wasm"

--- a/templates/assembly-script/HIPPOFACTS
+++ b/templates/assembly-script/HIPPOFACTS
@@ -1,0 +1,7 @@
+[bindle]
+name = "<%= moduleName %>"
+version = "0.1.0"
+authors = ["<%= authorName %>"]
+
+[files]
+wasm = ["build/optimized.wasm"]

--- a/templates/assembly-script/assembly/index.ts
+++ b/templates/assembly-script/assembly/index.ts
@@ -2,4 +2,5 @@ import "wasi";
 
 import { Console } from "as-wasi";
 
-Console.log("Hello, world!");
+<% if (wagi) { %>Console.log("Content-Type: text/plain\n");
+<% } %>Console.log("Hello, world!");

--- a/templates/c/.github/workflows/release.hippo.yml
+++ b/templates/c/.github/workflows/release.hippo.yml
@@ -47,5 +47,10 @@ jobs:
         wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.2.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
         tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
 
-    - name: Publish bindle
+    - name: Publish bindle (tagged)
+      if: startsWith(github.ref, 'refs/tags/v')
       run: ./tools/hippofactory . -v production -o message
+
+    - name: Publish bindle (main)
+      if: github.ref == 'refs/heads/main'
+      run: USER=canary ./tools/hippofactory . -o message

--- a/templates/c/.github/workflows/release.hippo.yml
+++ b/templates/c/.github/workflows/release.hippo.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Install hippofactory
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.2.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
+        wget https://github.com/deislabs/hippofactory/releases/download/v0.3.0/hippofactory-v0.3.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
         tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
 
     - name: Publish bindle (tagged)

--- a/templates/c/.github/workflows/release.hippo.yml
+++ b/templates/c/.github/workflows/release.hippo.yml
@@ -1,0 +1,51 @@
+name: release
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+env:
+  ACR_NAME: <%= registryName %>
+
+jobs:
+  publish:
+    strategy:
+      matrix:
+        wasi_sdk_version:
+        - major: 11
+          minor: 0
+
+    name: Build release assets
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install clang bits
+      run: |
+        wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${{ matrix.wasi_sdk_version.major }}/wasi-sdk-${{ matrix.wasi_sdk_version.major }}.${{ matrix.wasi_sdk_version.minor }}-linux.tar.gz
+        tar xvf wasi-sdk-${{ matrix.wasi_sdk_version.major }}.${{ matrix.wasi_sdk_version.minor }}-linux.tar.gz
+
+    - name: Set the release version (tag)
+      if: startsWith(github.ref, 'refs/tags/v')
+      shell: bash
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    - name: Set the release version (main)
+      if: github.ref == 'refs/heads/main'
+      shell: bash
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
+
+    - name: Build release
+      run: make WASI_SDK=wasi-sdk-${{ matrix.wasi_sdk_version.major }}.${{ matrix.wasi_sdk_version.minor }}
+
+    - name: Install hippofactory
+      run: |
+        mkdir -p tools/tmp
+        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.1.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
+        tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
+
+    - name: Publish bindle
+      run: ./tools/hippofactory . -v production -o message

--- a/templates/c/.github/workflows/release.hippo.yml
+++ b/templates/c/.github/workflows/release.hippo.yml
@@ -7,7 +7,7 @@ on:
       - "v*"
 
 env:
-  ACR_NAME: <%= registryName %>
+  BINDLE_SERVER_URL: <%= serverUrl %>
 
 jobs:
   publish:

--- a/templates/c/.github/workflows/release.hippo.yml
+++ b/templates/c/.github/workflows/release.hippo.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Install hippofactory
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.1.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
+        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.2.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
         tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
 
     - name: Publish bindle

--- a/templates/c/HIPPOFACTS
+++ b/templates/c/HIPPOFACTS
@@ -3,5 +3,6 @@ name = "<%= moduleName %>"
 version = "0.1.0"
 authors = ["<%= authorName %>"]
 
-[files]
-wasm = ["<%= moduleName %>.wasm"]
+[[handler]]
+route = "/"
+name = "<%= moduleName %>.wasm"

--- a/templates/c/HIPPOFACTS
+++ b/templates/c/HIPPOFACTS
@@ -1,0 +1,7 @@
+[bindle]
+name = "<%= moduleName %>"
+version = "0.1.0"
+authors = ["<%= authorName %>"]
+
+[files]
+wasm = ["<%= moduleName %>.wasm"]

--- a/templates/c/src/main.c
+++ b/templates/c/src/main.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 
-int main() {
+int main() {<% if (wagi) { %>
+  printf("Content-Type: text/plain\n\n");<% } %>
   printf("Hello, world!\n");
   return 0;
 }

--- a/templates/rust/.github/workflows/release.hippo.yml
+++ b/templates/rust/.github/workflows/release.hippo.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install hippofactory
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.1.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
+        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.2.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
         tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
 
     - name: Publish bindle

--- a/templates/rust/.github/workflows/release.hippo.yml
+++ b/templates/rust/.github/workflows/release.hippo.yml
@@ -39,5 +39,10 @@ jobs:
         wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.2.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
         tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
 
-    - name: Publish bindle
+    - name: Publish bindle (tagged)
+      if: startsWith(github.ref, 'refs/tags/v')
       run: ./tools/hippofactory . -v production -o message
+
+    - name: Publish bindle (main)
+      if: github.ref == 'refs/heads/main'
+      run: USER=canary ./tools/hippofactory . -o message

--- a/templates/rust/.github/workflows/release.hippo.yml
+++ b/templates/rust/.github/workflows/release.hippo.yml
@@ -1,0 +1,43 @@
+name: release
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+env:
+  BINDLE_SERVER_URL: <%= serverUrl %>
+
+jobs:
+  publish:
+    name: Build and publish release assets
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Rust bits
+      run: rustup target add wasm32-wasi
+
+    - name: Set the release version (tag)
+      if: startsWith(github.ref, 'refs/tags/v')
+      shell: bash
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    - name: Set the release version (main)
+      if: github.ref == 'refs/heads/main'
+      shell: bash
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
+
+    - name: Build release
+      run: cargo build --verbose --target wasm32-wasi --release
+
+    - name: Install hippofactory
+      run: |
+        mkdir -p tools/tmp
+        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.1.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
+        tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
+
+    - name: Publish bindle
+      run: ./tools/hippofactory . -v production -o message

--- a/templates/rust/.github/workflows/release.hippo.yml
+++ b/templates/rust/.github/workflows/release.hippo.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install hippofactory
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.2.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
+        wget https://github.com/deislabs/hippofactory/releases/download/v0.3.0/hippofactory-v0.3.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
         tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
 
     - name: Publish bindle (tagged)

--- a/templates/rust/.vscode/tasks.json
+++ b/templates/rust/.vscode/tasks.json
@@ -14,6 +14,12 @@
             "command": "cargo",
             "args": ["build", "--target", "wasm32-wasi"],
             "problemMatcher": ["$rustc"]
-        }
+          },
+          {
+            "label": "#OPT:Hippo# Hippo: Publish Development Build",
+            "type": "shell",
+            "command": "hippofactory",
+            "args": ["."]
+          }
     ]
 }

--- a/templates/rust/HIPPOFACTS
+++ b/templates/rust/HIPPOFACTS
@@ -1,0 +1,7 @@
+[bindle]
+name = "<%= moduleName %>"
+version = "0.1.0"
+authors = ["<%= authorName %>"]
+
+[files]
+wasm = ["target/wasm32-wasi/release/<%= moduleName %>.wasm"]

--- a/templates/rust/HIPPOFACTS
+++ b/templates/rust/HIPPOFACTS
@@ -3,5 +3,6 @@ name = "<%= moduleName %>"
 version = "0.1.0"
 authors = ["<%= authorName %>"]
 
-[files]
-wasm = ["target/wasm32-wasi/release/<%= moduleName %>.wasm"]
+[[handler]]
+route = "/"
+name = "target/wasm32-wasi/release/<%= moduleName %>.wasm"

--- a/templates/rust/src/main.rs
+++ b/templates/rust/src/main.rs
@@ -1,3 +1,4 @@
-fn main() {
-    println!("Hello, world!");
+fn main() {<% if (wagi) { %>
+  println!("Content-Type: text/plain\n");<% } %>
+  println!("Hello, world!");
 }

--- a/templates/swift/.github/workflows/release.hippo.yml
+++ b/templates/swift/.github/workflows/release.hippo.yml
@@ -64,5 +64,10 @@ jobs:
         wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.2.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
         tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
 
-    - name: Publish bindle
+    - name: Publish bindle (tagged)
+      if: startsWith(github.ref, 'refs/tags/v')
       run: ./tools/hippofactory . -v production -o message
+
+    - name: Publish bindle (main)
+      if: github.ref == 'refs/heads/main'
+      run: USER=canary ./tools/hippofactory . -o message

--- a/templates/swift/.github/workflows/release.hippo.yml
+++ b/templates/swift/.github/workflows/release.hippo.yml
@@ -1,0 +1,68 @@
+name: release
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+env:
+  ACR_NAME: <%= registryName %>
+
+jobs:
+  publish:
+    strategy:
+      matrix:
+        wasi_sdk_version:
+        - major: 11
+          minor: 0
+
+    name: Build release assets
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install SwiftWasm
+      run: |
+        sudo apt-get install \
+          binutils \
+          git \
+          gnupg2 \
+          libc6-dev \
+          libcurl4 \
+          libedit2 \
+          libgcc-9-dev \
+          libpython2.7 \
+          libsqlite3-0 \
+          libstdc++-9-dev \
+          libxml2 \
+          libz3-dev \
+          pkg-config \
+          tzdata \
+          zlib1g-dev
+        wget https://github.com/swiftwasm/swift/releases/download/swift-wasm-5.3.0-RELEASE/swift-wasm-5.3.0-RELEASE-ubuntu20.04_x86_64.tar.gz
+        sudo tar zxvf swift-wasm-5.3.0-RELEASE-ubuntu20.04_x86_64.tar.gz --directory / --strip-components=1
+        sudo chmod -R o+r /usr/lib/swift
+
+    - name: Set the release version (tag)
+      if: startsWith(github.ref, 'refs/tags/v')
+      shell: bash
+      run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    - name: Set the release version (main)
+      if: github.ref == 'refs/heads/main'
+      shell: bash
+      run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
+
+    - name: Build release
+      run: SWIFTC=/usr/bin/swift make build
+
+    - name: Install hippofactory
+      run: |
+        mkdir -p tools/tmp
+        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.1.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
+        tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
+
+    - name: Publish bindle
+      run: ./tools/hippofactory . -v production -o message

--- a/templates/swift/.github/workflows/release.hippo.yml
+++ b/templates/swift/.github/workflows/release.hippo.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install hippofactory
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.1.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
+        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.2.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
         tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
 
     - name: Publish bindle

--- a/templates/swift/.github/workflows/release.hippo.yml
+++ b/templates/swift/.github/workflows/release.hippo.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install hippofactory
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippofactory/releases/download/v0.2.0/hippofactory-v0.2.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
+        wget https://github.com/deislabs/hippofactory/releases/download/v0.3.0/hippofactory-v0.3.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippofactory.tar.gz
         tar xf ./tools/tmp/hippofactory.tar.gz -C ./tools
 
     - name: Publish bindle (tagged)

--- a/templates/swift/.github/workflows/release.hippo.yml
+++ b/templates/swift/.github/workflows/release.hippo.yml
@@ -7,7 +7,7 @@ on:
       - "v*"
 
 env:
-  ACR_NAME: <%= registryName %>
+  BINDLE_SERVER_URL: <%= serverUrl %>
 
 jobs:
   publish:

--- a/templates/swift/HIPPOFACTS
+++ b/templates/swift/HIPPOFACTS
@@ -3,5 +3,6 @@ name = "<%= moduleName %>"
 version = "0.1.0"
 authors = ["<%= authorName %>"]
 
-[files]
-wasm = ["<%= moduleName %>.wasm"]
+[[handler]]
+route = "/"
+name = "<%= moduleName %>.wasm"

--- a/templates/swift/HIPPOFACTS
+++ b/templates/swift/HIPPOFACTS
@@ -1,0 +1,7 @@
+[bindle]
+name = "<%= moduleName %>"
+version = "0.1.0"
+authors = ["<%= authorName %>"]
+
+[files]
+wasm = ["<%= moduleName %>.wasm"]

--- a/templates/swift/src/main.swift
+++ b/templates/swift/src/main.swift
@@ -1,1 +1,2 @@
-print("Hello!")
+<% if (wagi) { %>print("Content-Type: text/plain\n");
+<% } %>print("Hello!")

--- a/ts/generators/app/formatter.ts
+++ b/ts/generators/app/formatter.ts
@@ -1,0 +1,41 @@
+import { default as chalk } from 'chalk';
+
+export interface Formatter {
+  ev(text: string): string;
+  instr(text: string): string;
+  cmd(text: string): string;
+  emph(text: string): string;
+}
+
+class MarkdownFormatter implements Formatter {
+  ev(text: string): string {
+    return `**${text}**`;
+  }
+  instr(text: string): string {
+    return `**${text}**`;
+  }
+  cmd(text: string): string {
+    return '`' + text + '`';
+  }
+  emph(text: string): string {
+    return `**${text}**`;
+  }
+}
+
+class ChalkFormatter implements Formatter {
+  ev(text: string): string {
+    return chalk.cyan(text);
+  }
+  instr(text: string): string {
+    return chalk.yellow(text);
+  }
+  cmd(text: string): string {
+    return chalk.yellow(text);
+  }
+  emph(text: string): string {
+    return chalk.yellow(text);
+  }
+}
+
+export const FMT_MARKDOWN: Formatter = new MarkdownFormatter();
+export const FMT_CHALK: Formatter = new ChalkFormatter();

--- a/ts/generators/app/index.ts
+++ b/ts/generators/app/index.ts
@@ -19,6 +19,9 @@ const REGISTRY_CHOICE_ACR = "Azure Container Registry";
 const REGISTRY_CHOICE_HIPPO = "Hippo";
 const REGISTRY_CHOICE_NONE = "I don't want to publish the module";
 
+const PROJ_KIND_CONSOLE = "Console or batch job";
+const PROJ_KIND_WAGI = "Web service or application using WAGI";
+
 module.exports = class extends Generator {
   private answers: any = undefined;
 
@@ -40,6 +43,15 @@ module.exports = class extends Generator {
         name: 'moduleName',
         message: 'What is the name of the WASM module?',
         default: appname
+      },
+      {
+        type: 'list',
+        name: 'moduleKind',
+        message: 'What type of application is the module?',
+        choices: [
+          PROJ_KIND_CONSOLE,
+          PROJ_KIND_WAGI,
+        ],
       },
       {
         type: 'input',
@@ -80,8 +92,10 @@ module.exports = class extends Generator {
     const providerPrompts = providerSpecificPrompts(answers);
     const providerAnswers = await this.prompt(providerPrompts);
 
+    const answerConversions = simplify(answers);
+
     // To access answers later, use this.answers.*
-    this.answers = Object.assign({}, answers, languageAnswers, providerAnswers);
+    this.answers = Object.assign({}, answers, languageAnswers, providerAnswers, answerConversions);
   }
 
   writing() {
@@ -230,6 +244,12 @@ function removeSuppressionExtension(path: string): string {
     return path.substring(0, path.length - '.removeext'.length);
   }
   return path;
+}
+
+function simplify(answers: any): any {
+  return {
+    wagi: (answers.moduleKind === PROJ_KIND_WAGI),
+  };
 }
 
 interface TasksFile {

--- a/ts/generators/app/languages/language.ts
+++ b/ts/generators/app/languages/language.ts
@@ -1,7 +1,8 @@
+import { Formatter } from "../formatter";
 import { Errorable } from "../utils/errorable";
 
 export interface Language {
-  instructions(): ReadonlyArray<string>;
+  instructions(formatter: Formatter): ReadonlyArray<string>;
   templateFolder(): string;
   templateFiles(): ReadonlyArray<string>;
   offerToInstallTools(): Promise<string | undefined>;

--- a/ts/generators/app/languages/rust.ts
+++ b/ts/generators/app/languages/rust.ts
@@ -24,6 +24,7 @@ export const rust: Language = {
     return [
       '.gitignore.removeext',
       'Cargo.toml',
+      'HIPPOFACTS',
       'LICENSE',
       'README.md',
       '.cargo/config.toml',

--- a/ts/generators/app/languages/rust.ts
+++ b/ts/generators/app/languages/rust.ts
@@ -1,18 +1,17 @@
-import { default as chalk } from 'chalk';
-
+import { Formatter } from '../formatter';
 import { Errorable } from '../utils/errorable';
 import { Language } from './language';
 
 export const rust: Language = {
-  instructions(): ReadonlyArray<string> {
+  instructions(fmt: Formatter): ReadonlyArray<string> {
     return [
       "You'll need the following to build and run this project locally:",
       "* Rust: https://www.rust-lang.org/tools/install",
-      `* WASM target: ${chalk.yellow('rustup target add wasm32-wasi')}.`,
-      `* wasmtime: ${chalk.yellow('curl https://wasmtime.dev/install.sh -sSf | bash')}`,
+      `* WASM target: ${fmt.cmd('rustup target add wasm32-wasi')}.`,
+      `* wasmtime: ${fmt.cmd('curl https://wasmtime.dev/install.sh -sSf | bash')}`,
       '',
-      `Build using VS Code ${chalk.yellow('Build WASM')} task or ${chalk.yellow('cargo build-wasm')}.`,
-      `Run using VS Code ${chalk.yellow('Debug WASM')} task or ${chalk.yellow('wasmtime')} CLI.`,
+      `Build using VS Code ${fmt.instr('Build WASM')} task or ${fmt.cmd('cargo build-wasm')}.`,
+      `Run using VS Code ${fmt.instr('Debug WASM')} task or ${fmt.cmd('wasmtime')} CLI.`,
     ];
   },
 

--- a/ts/generators/app/providers/acr.ts
+++ b/ts/generators/app/providers/acr.ts
@@ -1,7 +1,7 @@
 import Generator = require('yeoman-generator');
-import { default as chalk } from 'chalk';
 
 import { Registry } from "./registry";
+import { Formatter } from '../formatter';
 
 export const acr: Registry = {
   prompts(answers: any): Generator.Questions<any> {
@@ -15,22 +15,26 @@ export const acr: Registry = {
     ];
   },
 
-  instructions(): ReadonlyArray<string> {
+  workflowInstructions(fmt: Formatter): ReadonlyArray<string> {
     return [
       'The release workflow depends on one variable and two secrets:',
       '',
-      `* ${chalk.cyan('ACR_NAME')} (defined in .github/workflows/release.yml): the`,
+      `* ${fmt.ev('ACR_NAME')} (defined in .github/workflows/release.yml): the`,
       '  name of the Azure Container Registry where you\'d like to',
       '  publish releases. We\'ve set this up for you.',
-      `* ${chalk.cyan('ACR_SP_ID')} (secret you need to create in GitHub): the ID`,
+      `* ${fmt.ev('ACR_SP_ID')} (secret you need to create in GitHub): the ID`,
       '  of a service principal with push access to the registry.',
-      `* ${chalk.cyan('ACR_SP_PASSWORD')} (secret you need to create in GitHub): the`,
+      `* ${fmt.ev('ACR_SP_PASSWORD')} (secret you need to create in GitHub): the`,
       '  password of the service principal identified in ACR_SP_ID.',
       '',
       'See https://bit.ly/2ZsmeQS for creating a service principal',
       'for use with ACR, and https://bit.ly/2ZqS3cB for creating the',
       'secrets in your GitHub repository.',
     ];
+  },
+
+  localInstructions(): ReadonlyArray<string> {
+    return [];
   },
 
   languageFiles(): ReadonlyArray<string> {

--- a/ts/generators/app/providers/acr.ts
+++ b/ts/generators/app/providers/acr.ts
@@ -33,6 +33,10 @@ export const acr: Registry = {
     ];
   },
 
+  languageFiles(): ReadonlyArray<string> {
+    return [];
+  },
+
   releaseTemplate(): string {
     return 'release.azurecr.yml';
   }

--- a/ts/generators/app/providers/hippo.ts
+++ b/ts/generators/app/providers/hippo.ts
@@ -1,7 +1,7 @@
 import Generator = require('yeoman-generator');
-import { default as chalk } from 'chalk';
 
 import { Registry } from "./registry";
+import { Formatter } from '../formatter';
 
 export const hippo: Registry = {
   prompts(): Generator.Questions<any> {
@@ -15,21 +15,28 @@ export const hippo: Registry = {
     ];
   },
 
-  instructions(): ReadonlyArray<string> {
+  workflowInstructions(fmt: Formatter): ReadonlyArray<string> {
     return [
       'The release workflow depends on one variable and two secrets:',
       '',
-      `* ${chalk.cyan('BINDLE_URL')} (defined in .github/workflows/release.yml): the`,
+      `* ${fmt.ev('BINDLE_URL')} (defined in .github/workflows/release.yml): the`,
       '  URL of the Bindle server where you\'d like to',
       '  publish releases. We\'ve set this up for you.',
-      `* ${chalk.cyan('BINDLE_USER_ID')} (secret you need to create in GitHub): the ID`,
+      `* ${fmt.ev('BINDLE_USER_ID')} (secret you need to create in GitHub): the ID`,
       '  of a user with push access to the Bindle server.',
-      `* ${chalk.cyan('BINDLE_PASSWORD')} (secret you need to create in GitHub): the`,
+      `* ${fmt.ev('BINDLE_PASSWORD')} (secret you need to create in GitHub): the`,
       '  password of the user identified in BINDLE_USER_ID.',
       '',
       'See https://bit.ly/2ZqS3cB for more information about creating the',
       'secrets in your GitHub repository.',
     ];
+  },
+
+  localInstructions(fmt: Formatter): ReadonlyArray<string> {
+    return [
+      `* ${fmt.emph('You will need the Hippo uploader to publish dev builds.')} Download this from`,
+      '  https://github.com/deislabs/hippofactory/releases and install on your path.',
+    ]
   },
 
   languageFiles(): ReadonlyArray<string> {

--- a/ts/generators/app/providers/hippo.ts
+++ b/ts/generators/app/providers/hippo.ts
@@ -1,0 +1,42 @@
+import Generator = require('yeoman-generator');
+import { default as chalk } from 'chalk';
+
+import { Registry } from "./registry";
+
+export const hippo: Registry = {
+  prompts(): Generator.Questions<any> {
+    return [
+      {
+        type: 'input',
+        name: 'serverUrl',
+        message: "What is the URL of your Hippo's Bindle server?",
+        default: 'https://bindle.hippos.rocks/v1',
+      }
+    ];
+  },
+
+  instructions(): ReadonlyArray<string> {
+    return [
+      'The release workflow depends on one variable and two secrets:',
+      '',
+      `* ${chalk.cyan('BINDLE_URL')} (defined in .github/workflows/release.yml): the`,
+      '  URL of the Bindle server where you\'d like to',
+      '  publish releases. We\'ve set this up for you.',
+      `* ${chalk.cyan('BINDLE_USER_ID')} (secret you need to create in GitHub): the ID`,
+      '  of a user with push access to the Bindle server.',
+      `* ${chalk.cyan('BINDLE_PASSWORD')} (secret you need to create in GitHub): the`,
+      '  password of the user identified in BINDLE_USER_ID.',
+      '',
+      'See https://bit.ly/2ZqS3cB for more information about creating the',
+      'secrets in your GitHub repository.',
+    ];
+  },
+
+  languageFiles(): ReadonlyArray<string> {
+    return ['HIPPOFACTS'];
+  },
+
+  releaseTemplate(): string {
+    return 'release.hippo.yml';
+  }
+}

--- a/ts/generators/app/providers/none.ts
+++ b/ts/generators/app/providers/none.ts
@@ -2,7 +2,8 @@ import Generator = require('yeoman-generator');
 
 export const noRegistry = {
   prompts(): Generator.Questions<any> { return []; },
-  instructions(): ReadonlyArray<string> { return []; },
+  localInstructions(): ReadonlyArray<string> { return []; },
+  workflowInstructions(): ReadonlyArray<string> { return []; },
   languageFiles(): ReadonlyArray<string> { return []; },
   releaseTemplate(): string { return 'release.nopublish.yml'; }
 }

--- a/ts/generators/app/providers/none.ts
+++ b/ts/generators/app/providers/none.ts
@@ -3,5 +3,6 @@ import Generator = require('yeoman-generator');
 export const noRegistry = {
   prompts(): Generator.Questions<any> { return []; },
   instructions(): ReadonlyArray<string> { return []; },
+  languageFiles(): ReadonlyArray<string> { return []; },
   releaseTemplate(): string { return 'release.nopublish.yml'; }
 }

--- a/ts/generators/app/providers/registry.ts
+++ b/ts/generators/app/providers/registry.ts
@@ -1,8 +1,10 @@
 import Generator = require('yeoman-generator');
+import { Formatter } from '../formatter';
 
 export interface Registry {
   prompts(answers: any): Generator.Questions<any>;
-  instructions(answers: any): ReadonlyArray<string>;
+  localInstructions(fmt: Formatter, answers: any): ReadonlyArray<string>;
+  workflowInstructions(fmt: Formatter, answers: any): ReadonlyArray<string>;
   languageFiles(): ReadonlyArray<string>;
   releaseTemplate(): string;
 }

--- a/ts/generators/app/providers/registry.ts
+++ b/ts/generators/app/providers/registry.ts
@@ -3,5 +3,6 @@ import Generator = require('yeoman-generator');
 export interface Registry {
   prompts(answers: any): Generator.Questions<any>;
   instructions(answers: any): ReadonlyArray<string>;
+  languageFiles(): ReadonlyArray<string>;
   releaseTemplate(): string;
 }


### PR DESCRIPTION
This adds options to:

1. Create a "Web application or service using WAGI" (which just adds a Content-Type header to the "hello world" template)
2. Publish to Hippo instead of an OCI registry (which uses a hippofactory-based publish template to push artifacts to Bindle, though doesn't truly do anything with Hippo yet)

I haven't been able to properly test all the languages so all eyeballs for careless copypasta would be super valuable - thanks!