### PR TITLE
Add Bindle authentication to Hippo publish actions

### DIFF
--- a/templates/assembly-script/.github/workflows/release.hippo.yml
+++ b/templates/assembly-script/.github/workflows/release.hippo.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Install Hippo CLI
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippo-cli/releases/download/v0.8.0/hippo-v0.8.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
+        wget https://github.com/deislabs/hippo-cli/releases/download/v0.9.0/hippo-v0.9.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
         tar xf ./tools/tmp/hippo.tar.gz -C ./tools
 
     - name: Publish bindle (tagged)

--- a/templates/assembly-script/.github/workflows/release.hippo.yml
+++ b/templates/assembly-script/.github/workflows/release.hippo.yml
@@ -49,6 +49,8 @@ jobs:
       env:
         HIPPO_USERNAME: ${{ secrets.HIPPO_USERNAME }}
         HIPPO_PASSWORD: ${{ secrets.HIPPO_PASSWORD }}
+        BINDLE_USERNAME: ${{ secrets.BINDLE_USERNAME }}
+        BINDLE_PASSWORD: ${{ secrets.BINDLE_PASSWORD }}
       run: ./tools/hippo push . -v production -o message
 
     - name: Publish bindle (main)
@@ -56,4 +58,6 @@ jobs:
       env:
         HIPPO_USERNAME: ${{ secrets.HIPPO_USERNAME }}
         HIPPO_PASSWORD: ${{ secrets.HIPPO_PASSWORD }}
+        BINDLE_USERNAME: ${{ secrets.BINDLE_USERNAME }}
+        BINDLE_PASSWORD: ${{ secrets.BINDLE_PASSWORD }}
       run: USER=canary ./tools/hippo push . -o message

--- a/templates/assembly-script/.github/workflows/release.hippo.yml
+++ b/templates/assembly-script/.github/workflows/release.hippo.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Install Hippo CLI
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippo-cli/releases/download/v0.7.0/hippo-v0.7.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
+        wget https://github.com/deislabs/hippo-cli/releases/download/v0.8.0/hippo-v0.8.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
         tar xf ./tools/tmp/hippo.tar.gz -C ./tools
 
     - name: Publish bindle (tagged)

--- a/templates/c/.github/workflows/release.hippo.yml
+++ b/templates/c/.github/workflows/release.hippo.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install Hippo CLI
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippo-cli/releases/download/v0.7.0/hippo-v0.7.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
+        wget https://github.com/deislabs/hippo-cli/releases/download/v0.8.0/hippo-v0.8.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
         tar xf ./tools/tmp/hippo.tar.gz -C ./tools
 
     - name: Publish bindle (tagged)

--- a/templates/c/.github/workflows/release.hippo.yml
+++ b/templates/c/.github/workflows/release.hippo.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install Hippo CLI
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippo-cli/releases/download/v0.8.0/hippo-v0.8.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
+        wget https://github.com/deislabs/hippo-cli/releases/download/v0.9.0/hippo-v0.9.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
         tar xf ./tools/tmp/hippo.tar.gz -C ./tools
 
     - name: Publish bindle (tagged)

--- a/templates/c/.github/workflows/release.hippo.yml
+++ b/templates/c/.github/workflows/release.hippo.yml
@@ -53,6 +53,8 @@ jobs:
       env:
         HIPPO_USERNAME: ${{ secrets.HIPPO_USERNAME }}
         HIPPO_PASSWORD: ${{ secrets.HIPPO_PASSWORD }}
+        BINDLE_USERNAME: ${{ secrets.BINDLE_USERNAME }}
+        BINDLE_PASSWORD: ${{ secrets.BINDLE_PASSWORD }}
       run: ./tools/hippo push . -v production -o message
 
     - name: Publish bindle (main)
@@ -60,4 +62,6 @@ jobs:
       env:
         HIPPO_USERNAME: ${{ secrets.HIPPO_USERNAME }}
         HIPPO_PASSWORD: ${{ secrets.HIPPO_PASSWORD }}
+        BINDLE_USERNAME: ${{ secrets.BINDLE_USERNAME }}
+        BINDLE_PASSWORD: ${{ secrets.BINDLE_PASSWORD }}
       run: USER=canary ./tools/hippo push . -o message

--- a/templates/rust/.github/workflows/release.hippo.yml
+++ b/templates/rust/.github/workflows/release.hippo.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install Hippo CLI
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippo-cli/releases/download/v0.7.0/hippo-v0.7.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
+        wget https://github.com/deislabs/hippo-cli/releases/download/v0.8.0/hippo-v0.8.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
         tar xf ./tools/tmp/hippo.tar.gz -C ./tools
 
     - name: Publish bindle (tagged)

--- a/templates/rust/.github/workflows/release.hippo.yml
+++ b/templates/rust/.github/workflows/release.hippo.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install Hippo CLI
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippo-cli/releases/download/v0.8.0/hippo-v0.8.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
+        wget https://github.com/deislabs/hippo-cli/releases/download/v0.9.0/hippo-v0.9.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
         tar xf ./tools/tmp/hippo.tar.gz -C ./tools
 
     - name: Publish bindle (tagged)

--- a/templates/rust/.github/workflows/release.hippo.yml
+++ b/templates/rust/.github/workflows/release.hippo.yml
@@ -45,6 +45,8 @@ jobs:
       env:
         HIPPO_USERNAME: ${{ secrets.HIPPO_USERNAME }}
         HIPPO_PASSWORD: ${{ secrets.HIPPO_PASSWORD }}
+        BINDLE_USERNAME: ${{ secrets.BINDLE_USERNAME }}
+        BINDLE_PASSWORD: ${{ secrets.BINDLE_PASSWORD }}
       run: ./tools/hippo push . -v production -o message
 
     - name: Publish bindle (main)
@@ -52,4 +54,6 @@ jobs:
       env:
         HIPPO_USERNAME: ${{ secrets.HIPPO_USERNAME }}
         HIPPO_PASSWORD: ${{ secrets.HIPPO_PASSWORD }}
+        BINDLE_USERNAME: ${{ secrets.BINDLE_USERNAME }}
+        BINDLE_PASSWORD: ${{ secrets.BINDLE_PASSWORD }}
       run: USER=canary ./tools/hippo push . -o message

--- a/templates/swift/.github/workflows/release.hippo.yml
+++ b/templates/swift/.github/workflows/release.hippo.yml
@@ -70,6 +70,8 @@ jobs:
       env:
         HIPPO_USERNAME: ${{ secrets.HIPPO_USERNAME }}
         HIPPO_PASSWORD: ${{ secrets.HIPPO_PASSWORD }}
+        BINDLE_USERNAME: ${{ secrets.BINDLE_USERNAME }}
+        BINDLE_PASSWORD: ${{ secrets.BINDLE_PASSWORD }}
       run: ./tools/hippo push . -v production -o message
 
     - name: Publish bindle (main)
@@ -77,4 +79,6 @@ jobs:
       env:
         HIPPO_USERNAME: ${{ secrets.HIPPO_USERNAME }}
         HIPPO_PASSWORD: ${{ secrets.HIPPO_PASSWORD }}
+        BINDLE_USERNAME: ${{ secrets.BINDLE_USERNAME }}
+        BINDLE_PASSWORD: ${{ secrets.BINDLE_PASSWORD }}
       run: USER=canary ./tools/hippo push . -o message

--- a/templates/swift/.github/workflows/release.hippo.yml
+++ b/templates/swift/.github/workflows/release.hippo.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install Hippo CLI
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippo-cli/releases/download/v0.7.0/hippo-v0.7.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
+        wget https://github.com/deislabs/hippo-cli/releases/download/v0.8.0/hippo-v0.8.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
         tar xf ./tools/tmp/hippo.tar.gz -C ./tools
 
     - name: Publish bindle (tagged)

--- a/templates/swift/.github/workflows/release.hippo.yml
+++ b/templates/swift/.github/workflows/release.hippo.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install Hippo CLI
       run: |
         mkdir -p tools/tmp
-        wget https://github.com/deislabs/hippo-cli/releases/download/v0.8.0/hippo-v0.8.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
+        wget https://github.com/deislabs/hippo-cli/releases/download/v0.9.0/hippo-v0.9.0-linux-amd64.tar.gz -q -O ./tools/tmp/hippo.tar.gz
         tar xf ./tools/tmp/hippo.tar.gz -C ./tools
 
     - name: Publish bindle (tagged)

--- a/ts/generators/app/providers/hippo.ts
+++ b/ts/generators/app/providers/hippo.ts
@@ -62,7 +62,7 @@ export const hippo: Registry = {
 
   workflowInstructions(fmt: Formatter): ReadonlyArray<string> {
     return [
-      'The release workflow depends on two variable and two secrets:',
+      'The release workflow depends on two variable and four secrets:',
       '',
       `* ${fmt.ev('HIPPO_URL')} (defined in .github/workflows/release.yml): the`,
       '  URL of the Hippo where you\'d like to',
@@ -74,10 +74,10 @@ export const hippo: Registry = {
       '  of a user with write permissions on the Hippo service.',
       `* ${fmt.ev('HIPPO_PASSWORD')} (secret you need to create in GitHub): the`,
       '  password of the user identified in HIPPO_USERNAME.',
-      // `* ${fmt.ev('BINDLE_USER_ID')} (secret you need to create in GitHub): the ID`,
-      // '  of a user with push access to the Bindle server.',
-      // `* ${fmt.ev('BINDLE_PASSWORD')} (secret you need to create in GitHub): the`,
-      // '  password of the user identified in BINDLE_USER_ID.',
+      `* ${fmt.ev('BINDLE_USERNAME')} (secret you need to create in GitHub): the ID`,
+      '  of a user with push access to the Bindle server.',
+      `* ${fmt.ev('BINDLE_PASSWORD')} (secret you need to create in GitHub): the`,
+      '  password of the user identified in BINDLE_USER_ID.',
       '',
       'See https://bit.ly/2ZqS3cB for more information about creating the',
       'secrets in your GitHub repository.',


### PR DESCRIPTION
Bindle is getting authentication.  `yo wasm` generates GitHub actions that push to Bindle, so now need to provide credentials.  With this PR, the actions now set the appropriate environment variables, and provide instructions on setting up the GitHub secrets correctly.  We also update the Hippo CLI reference to a forthcoming release that will have auth.

~~This PR is marked as draft only because the Hippo CLI release is not yet posted.  It is otherwise **ready for review.**~~

**Notes for reviewers:** The main thing is please proofread that I haven't messed up any of the names - `env` keys should match Hippo CLI environment variables and `secrets.*` references should match instructions.  Thanks!