### PR TITLE
chore(package-lock.json): updates from running from source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "generator-wasm",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "generator-wasm",
-      "version": "0.0.3",
-      "license": "MIT",
+      "version": "0.0.4",
+      "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^2.1.0",
-        "hippo-js": "https://github.com/deislabs/hippo-client-node/releases/download/0.0.2/hippo-js-0.0.2.tgz",
+        "hippo-js": "https://github.com/deislabs/hippo-client-node/releases/download/v0.0.2/hippo-js-0.0.2.tgz",
         "mkdirp": "^1.0.4",
         "shelljs": "^0.8.4",
         "yeoman-generator": "^2.0.1",
@@ -4168,7 +4168,7 @@
     },
     "node_modules/hippo-js": {
       "version": "0.0.2",
-      "resolved": "https://github.com/deislabs/hippo-client-node/releases/download/0.0.2/hippo-js-0.0.2.tgz",
+      "resolved": "https://github.com/deislabs/hippo-client-node/releases/download/v0.0.2/hippo-js-0.0.2.tgz",
       "integrity": "sha512-KoQn1j1PQAWtjvbLsrvUnkPc928JCwNvksWU9i9LHJbxtXYnaK4lFgFggvxOM3jr1Db/RoK/k8Qcw+Z8t3JsZA==",
       "license": "MIT",
       "dependencies": {
@@ -14375,7 +14375,7 @@
       }
     },
     "hippo-js": {
-      "version": "https://github.com/deislabs/hippo-client-node/releases/download/0.0.2/hippo-js-0.0.2.tgz",
+      "version": "https://github.com/deislabs/hippo-client-node/releases/download/v0.0.2/hippo-js-0.0.2.tgz",
       "integrity": "sha512-KoQn1j1PQAWtjvbLsrvUnkPc928JCwNvksWU9i9LHJbxtXYnaK4lFgFggvxOM3jr1Db/RoK/k8Qcw+Z8t3JsZA==",
       "requires": {
         "axios": "^0.21.1"


### PR DESCRIPTION
These changes appeared when following the [running from source](https://github.com/deislabs/yo-wasm#running-from-source) directions when on the latest/current commit on `main`.