### PR TITLE
Several updates to the TinyGo generator:

### DIFF
--- a/templates/tinygo/.github/workflows/build.yml
+++ b/templates/tinygo/.github/workflows/build.yml
@@ -16,12 +16,12 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.5
+        go-version: 1.17.5
 
-    - name: Install TinyGo 0.20.0
+    - name: Install TinyGo 0.21.0
       run: |
-        wget https://github.com/tinygo-org/tinygo/releases/download/v0.20.0/tinygo_0.20.0_amd64.deb
-        sudo dpkg -i tinygo_0.20.0_amd64.deb
+        wget https://github.com/tinygo-org/tinygo/releases/download/v0.21.0/tinygo_0.21.0_amd64.deb
+        sudo dpkg -i tinygo_0.21.0_amd64.deb
 
     - name: Build
       run: make build

--- a/templates/tinygo/.github/workflows/release.azurecr.yml
+++ b/templates/tinygo/.github/workflows/release.azurecr.yml
@@ -29,12 +29,12 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.5
+        go-version: 1.17.5
 
-    - name: Install TinyGo 0.20.0
+    - name: Install TinyGo 0.21.0
       run: |
-        wget https://github.com/tinygo-org/tinygo/releases/download/v0.20.0/tinygo_0.20.0_amd64.deb
-        sudo dpkg -i tinygo_0.20.0_amd64.deb
+        wget https://github.com/tinygo-org/tinygo/releases/download/v0.21.0/tinygo_0.21.0_amd64.deb
+        sudo dpkg -i tinygo_0.21.0_amd64.deb
 
     - name: Build release
       run: make build

--- a/templates/tinygo/.github/workflows/release.hippo.yml
+++ b/templates/tinygo/.github/workflows/release.hippo.yml
@@ -19,7 +19,7 @@ jobs:
           minor: 0
 
     name: Build release assets
-    runs-on: golang:1.16
+    runs-on: golang:1.17
 
     steps:
     - uses: actions/checkout@v2
@@ -33,10 +33,10 @@ jobs:
       shell: bash
       run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
 
-    - name: Install TinyGo 0.20.0
+    - name: Install TinyGo 0.21.0
       run: |
-        wget https://github.com/tinygo-org/tinygo/releases/download/v0.20.0/tinygo_0.20.0_amd64.deb
-        dpkg -i tinygo_0.20.0_amd64.deb
+        wget https://github.com/tinygo-org/tinygo/releases/download/v0.21.0/tinygo_0.21.0_amd64.deb
+        sudo dpkg -i tinygo_0.21.0_amd64.deb
 
     - name: Build release
       run: make build

--- a/templates/tinygo/.github/workflows/release.nopublish.yml
+++ b/templates/tinygo/.github/workflows/release.nopublish.yml
@@ -27,12 +27,12 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.5
+        go-version: 1.17.5
 
-    - name: Install TinyGo 0.20.0
+    - name: Install TinyGo 0.21.0
       run: |
-        wget https://github.com/tinygo-org/tinygo/releases/download/v0.20.0/tinygo_0.20.0_amd64.deb
-        sudo dpkg -i tinygo_0.20.0_amd64.deb
+        wget https://github.com/tinygo-org/tinygo/releases/download/v0.21.0/tinygo_0.21.0_amd64.deb
+        sudo dpkg -i tinygo_0.21.0_amd64.deb
 
     - name: Build release
       run: make build

--- a/templates/tinygo/.github/workflows/release.yml
+++ b/templates/tinygo/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16.5
+        go-version: 1.17.5
 
-    - name: Install TinyGo 0.20.0
+    - name: Install TinyGo 0.21.0
       run: |
-        wget https://github.com/tinygo-org/tinygo/releases/download/v0.20.0/tinygo_0.20.0_amd64.deb
-        sudo dpkg -i tinygo_0.20.0_amd64.deb
+        wget https://github.com/tinygo-org/tinygo/releases/download/v0.21.0/tinygo_0.21.0_amd64.deb
+        sudo dpkg -i tinygo_0.21.0_amd64.deb
 
     - name: Build release
       run: make build

--- a/templates/tinygo/.gitignore.removeext
+++ b/templates/tinygo/.gitignore.removeext
@@ -1,2 +1,22 @@
-# WASM output files
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
 *.wasm
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work

--- a/templates/tinygo/.vscode/tasks.json
+++ b/templates/tinygo/.vscode/tasks.json
@@ -15,6 +15,15 @@
             "label": "TinyGo: Build WASM",
             "type": "shell",
             "command": "make build"
-        }
+        },
+        {
+        "label": "#OPT:Hippo# Hippo: Publish Development Build",
+        "type": "shell",
+        "command": "hippo",
+        "args": [
+          "push",
+          "."
+        ]
+      }
     ]
 }

--- a/templates/tinygo/README.md
+++ b/templates/tinygo/README.md
@@ -5,6 +5,7 @@ A WASM hello-world written in Go and compiled into WASM via TinyGo
 You will need:
 * Go (v1.16 or higher): https://golang.org/doc/install
 * TinyGo: https://tinygo.org/getting-started/install
+* Make: https://www.gnu.org/software/make/"
 * wasmtime: `curl https://wasmtime.dev/install.sh -sSf | bash`
 
 To init: `make init`

--- a/templates/tinygo/src/main.go
+++ b/templates/tinygo/src/main.go
@@ -6,6 +6,8 @@ func Hello() string {
 	return "Hello, world!"
 }
 
-func main() {
+func main() {<% if (wagi) { %>
+	fmt.Println("Content-Type: text/plain")
+	fmt.Println("")<% } %>
 	fmt.Println(Hello())
 }

--- a/ts/generators/app/languages/tinygo.ts
+++ b/ts/generators/app/languages/tinygo.ts
@@ -8,6 +8,7 @@ export const tinygo: Language = {
       "You'll need the following to build and run this project locally:",
       "* TinyGo: https://tinygo.org/getting-started/install/",
       `* Go (v1.14+): https://golang.org/doc/install`,
+      "* Make: https://www.gnu.org/software/make/",
       `* wasmtime: ${fmt.cmd('curl https://wasmtime.dev/install.sh -sSf | bash')}`,
       '',
       "Next steps:",


### PR DESCRIPTION
* bump the Go version to 1.17.5 (recommended for TinyGo) and the TinyGo version to 0.21.0
* add a few other recommended excludes for Go projects
* add the hippo task similar to the rust project
* Update the readme to call out the Make dependency
* Add conditional output for WAGI targets - include sample headers
