### PR TITLE
TinyGo WASM builds fail on Windows unless the scheduler is defined.

### DIFF
--- a/templates/tinygo/Makefile
+++ b/templates/tinygo/Makefile
@@ -2,6 +2,10 @@ MODULE ?= <%= moduleName %>
 TARGET ?= $(MODULE).wasm
 SRC_DIR ?= ./src
 
+ifeq ($(OS),Windows_NT) 
+	SCHEDULER ?= -scheduler=none 
+endif
+
 default: build
 
 .PHONY: init
@@ -10,7 +14,7 @@ init:
 
 .PHONY: build
 build:
-	tinygo build -o $(TARGET) -target=wasi $(SRC_DIR)
+	tinygo build -o $(TARGET) $(SCHEDULER) -target=wasi $(SRC_DIR)
 
 .PHONY: test
 test:


### PR DESCRIPTION
Added a check in the makefile to see if the OS is Windows, and if so, add `-scheduler=none` to the build command.
